### PR TITLE
Fix bug in from_date

### DIFF
--- a/R/nettskjema_get_form.R
+++ b/R/nettskjema_get_form.R
@@ -81,7 +81,7 @@ nettskjema_get_data <- function(form_id,
     from_submission <- sprintf("fromSubmissionId=%s", from_submission)
   }
 
-  opts <- paste0("?", from_date, from_submission)
+  opts <- paste0("?", from_date, "&", from_submission)
 
   # get all submissionIds first, to create increments
   path_inc <- paste0(path, opts, "fields=submissionId")


### PR DESCRIPTION
from_date throws an error because it lacks an "&" between from_date and from_submission. Should work with the proposed fix. Hope the fix doesn't create any new errors of its own.

```R
nettskjema_get_data("110000", use_codebook = FALSE, from_date = "2021-05-20")

# > Invalid format: "2021-05-20fields=submissionId" is malformed at "fields=submissionId"

nettskjema_get_data("110000", use_codebook = FALSE, from_date = "2021-05-20&") # quick fix

# works
```